### PR TITLE
fix: update Prisma client generation command

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -10,9 +10,6 @@ COPY package.json bun.lock ./
 # Copy Prisma schema
 COPY prisma ./prisma/
 
-# Generate Prisma client (without accessing DB)
-RUN bunx prisma generate
-
 # Install dependencies
 RUN bun install
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "serve:api": "bun dist/api/index.js",
     "db:generate:dev": "dotenv -e .env.development.local -- prisma generate",
     "db:pull:dev": "dotenv -e .env.development.local -- prisma db pull",
-    "db:generate": "prisma generate",
+    "db:generate": "bunx prisma generate",
     "postinstall": "bun run db:generate",
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
Replace the Prisma client generation command in package.json to use 
'bunx' for consistency with the project's build toolchain. Remove the 
unnecessary client generation step from the Dockerfile to streamline 
the build process and avoid redundancy.